### PR TITLE
fix: Final fix for backend 500 errors and Firestore permissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -15,14 +15,16 @@ service cloud.firestore {
     
     // Users can read/write their own daily health metrics (water, steps, sleep)
     match /dailyHealthMetrics/{metricId} {
-      // Allow reading if the user's ID is in the document ID, which is structured as {userId}_{date}
-      allow read: if request.auth != null && metricId.split('_')[0] == request.auth.uid;
+      // Allow a user to 'get' their own doc by ID, even if it doesn't exist.
+      // This is crucial for checking if a metric for a day has been created.
+      allow get: if request.auth != null && metricId.split('_')[0] == request.auth.uid;
 
-      // Allow creating and updating (for set with merge).
-      // This checks the incoming document's data for the correct userId.
+      // Allow a user to 'list' (query) their own docs.
+      // This rule works for queries because the query must include `where('userId', '==', request.auth.uid)`.
+      allow list: if request.auth != null && resource.data.userId == request.auth.uid;
+
+      // Allow creating and updating if the incoming data has the correct userId.
       allow create, update: if request.auth != null && request.resource.data.userId == request.auth.uid;
-
-      // Note: delete is intentionally not allowed by this rule.
     }
 
     // Users can read/write their own health metrics


### PR DESCRIPTION
This commit includes two critical fixes to resolve issues reported in the deployment.

1.  **Backend 500 Errors:** The backend was failing to connect to Firebase Admin services due to an issue with parsing the `FIREBASE_SERVICE_ACCOUNT_KEY` from environment variables in Vercel. The `private_key` contains newline characters that were not being handled correctly.

    The `vercelServiceAccountHelper.js` has been updated to replace escaped newlines (`\\n`) with actual newlines (`\n`) before parsing the JSON, ensuring the Firebase Admin SDK is initialized correctly.

2.  **Firestore Security Rule Permissions:** The client was receiving "Missing or insufficient permissions" errors when accessing `dailyHealthMetrics`. The security rule for this collection was flawed. It has been updated to correctly handle `get` on non-existent documents and `list` (query) operations separately, which resolves the permissions error.